### PR TITLE
Simplify last step logic of the service creation wizard

### DIFF
--- a/src/app/service/components/master-peeker/master-picker-popover.component.html
+++ b/src/app/service/components/master-peeker/master-picker-popover.component.html
@@ -1,6 +1,6 @@
-<ion-list *ngIf="(masterList$|async).length">
+<ion-list *ngIf="(masterList$|async)?.length">
   <ion-list-header>
-    {{"service-publish.step-final.master-picker.popover-title"|translate}}
+    {{"service-publish.final-step.master-picker.popover-title"|translate}}
   </ion-list-header>
   <ion-item class="cursor-pointer" (click)="onMasterClick(master)" *ngFor="let master of (masterList$|async)">
     <ion-label>{{master.name}}</ion-label>

--- a/src/app/service/components/master-peeker/master-picker-popover.component.ts
+++ b/src/app/service/components/master-peeker/master-picker-popover.component.ts
@@ -1,34 +1,28 @@
 import {Component} from '@angular/core';
 import {Master} from '@app/core/models/master';
 import {MasterManagerService} from '@app/core/services/master-manager.service';
-import {Reinitable} from '@app/shared/abstract/reinitable';
-import {BehaviorSubject} from 'rxjs';
-import {tap} from 'rxjs/operators';
+import {PopoverController} from '@ionic/angular';
+import {Observable} from 'rxjs';
+
+export interface MasterPickerPopoverData {
+    master: Master;
+}
 
 @Component({
     selector: 'app-master-picker-popover',
     templateUrl: './master-picker-popover.component.html',
     styleUrls: ['./master-picker-popover.component.scss']
 })
-export class MasterPickerPopoverComponent extends Reinitable {
+export class MasterPickerPopoverComponent {
 
-    public static master$: BehaviorSubject<Master> = new BehaviorSubject<Master>(undefined);
-    public masterList$: BehaviorSubject<Master[]> = new BehaviorSubject<Master[]>([]);
+    public masterList$: Observable<Master[]>;
 
-    constructor(private readonly masterManager: MasterManagerService) {
-        super();
+    constructor(private readonly popoverController: PopoverController,
+                masterManager: MasterManagerService) {
+        this.masterList$ = masterManager.getMasterList();
     }
 
     public onMasterClick(master: Master): void {
-        MasterPickerPopoverComponent.master$.next(master);
-    }
-
-    protected init(): void {
-        MasterPickerPopoverComponent.master$.next(undefined);
-        this.masterManager.getMasterList().pipe(
-            tap((list: Master[]) => list.length === 0 ? MasterPickerPopoverComponent.master$.next(null) : null)
-        ).subscribe(
-            list => this.masterList$.next(list)
-        );
+        this.popoverController.dismiss({ master }).then();
     }
 }

--- a/src/app/service/components/service-publish-final-step/service-publish-final-step.component.ts
+++ b/src/app/service/components/service-publish-final-step/service-publish-final-step.component.ts
@@ -1,8 +1,9 @@
 import {Component} from '@angular/core';
+import { Router } from '@angular/router';
 import {Master} from '@app/core/models/master';
 import {MasterLocation} from '@app/master/models/master-location';
 import {MasterLocationApiService} from '@app/master/services/master-location-api.service';
-import {MasterPickerPopoverComponent} from '@app/service/components/master-peeker/master-picker-popover.component';
+import {MasterPickerPopoverComponent, MasterPickerPopoverData} from '@app/service/components/master-peeker/master-picker-popover.component';
 import {ServicePublishSteps} from '@app/service/enums/service-publish-steps';
 import {FinalStepDataInterface} from '@app/service/interfaces/final-step-data-interface';
 import {StepFourDataInterface} from '@app/service/interfaces/step-four-data-interface';
@@ -12,7 +13,7 @@ import {ServiceStepsNavigationService} from '@app/service/services/service-steps
 import {Reinitable} from '@app/shared/abstract/reinitable';
 import {ContactsAddComponent} from '@app/shared/components/contacts-add/contacts-add.component';
 import {PopoverController} from '@ionic/angular';
-import {Observable} from 'rxjs';
+import {OverlayEventDetail} from '@ionic/core';
 import {map} from 'rxjs/operators';
 
 @Component({
@@ -27,64 +28,42 @@ export class ServicePublishFinalStepComponent extends Reinitable {
         private readonly popoverController: PopoverController,
         private readonly servicePublishDataHolder: ServicePublishDataHolderService,
         public serviceStepsNavigationService: ServiceStepsNavigationService,
-        private readonly masterLocationApi: MasterLocationApiService
+        private readonly masterLocationApi: MasterLocationApiService,
+        private readonly router: Router
     ) {
         super();
     }
 
-    public publish(): void {
-        if (!this.servicePublishDataHolder.getStepData<StepFourDataInterface>(ServicePublishSteps.Four).isNewMaster) {
-            this.popover().then(() => this.servicePublish.publish().subscribe(
-                () => {
-                    // TODO: show feedback about operation success
-                }
-            ));
-        } else {
-            this.servicePublish.publish().subscribe(
-                () => {
-                    // TODO: show feedback about operation success
-                }
+    public async publish(): Promise<void> {
+        const isNewMaster = this.servicePublishDataHolder.getStepData<StepFourDataInterface>(ServicePublishSteps.Four).isNewMaster;
+        // TODO show master selector only when masters.length > 1
+        const master = isNewMaster ? null : await this.chooseMaster();
+        if (master) {
+            const masterLocation = await this.getMasterLocation(master);
+            await this.servicePublishDataHolder.setStepData<FinalStepDataInterface>(
+                ServicePublishSteps.Final, {master, masterLocation}
             );
         }
+        this.servicePublish.publish().subscribe((service) => this.router.navigate(['service', service.id ]));
     }
 
     protected init(): void {
         ContactsAddComponent.reinit$.next(true);
     }
 
-    private popover(): Promise<void> {
-        return new Promise<void>(resolve => {
-            this.popoverController.create({
-                component: MasterPickerPopoverComponent,
-                translucent: true
-            }).then(pop => pop.present().then(
-                () => {
-                    const subscription = MasterPickerPopoverComponent.master$.subscribe(
-                        (master: Master) => {
-                            if (master !== undefined) {
-                                this.getMasterLocation(master).subscribe(
-                                    masterLocation => this.servicePublishDataHolder.setStepData<FinalStepDataInterface>(
-                                        ServicePublishSteps.Final, {master, masterLocation}
-                                    ).then(() => this.servicePublishDataHolder.assignStepData(
-                                        ServicePublishSteps.Four, {isNewMaster: false}
-                                    ).then(
-                                        () => this.popoverController.dismiss().then(() => {
-                                            subscription.unsubscribe();
-                                            resolve();
-                                        })
-                                    ))
-                                );
-                            }
-                        }
-                    );
-                }
-            ));
+    private async chooseMaster(): Promise<Master> {
+        const popover = await this.popoverController.create({
+            component: MasterPickerPopoverComponent,
+            translucent: true
         });
+        await popover.present();
+
+        return popover.onDidDismiss().then((eventDetail: OverlayEventDetail<MasterPickerPopoverData>) => eventDetail.data.master);
     }
 
-    private getMasterLocation(master: Master): Observable<MasterLocation> {
+    private getMasterLocation(master: Master): Promise<MasterLocation> {
         return this.masterLocationApi.getByClientId(master.id).pipe(
             map(list => list.results.length === 0 ? null : list.results[0])
-        );
+        ).toPromise();
     }
 }

--- a/src/app/service/components/service-publish-final-step/service-publish-final-step.component.ts
+++ b/src/app/service/components/service-publish-final-step/service-publish-final-step.component.ts
@@ -14,7 +14,7 @@ import {Reinitable} from '@app/shared/abstract/reinitable';
 import {ContactsAddComponent} from '@app/shared/components/contacts-add/contacts-add.component';
 import {PopoverController} from '@ionic/angular';
 import {OverlayEventDetail} from '@ionic/core';
-import {map} from 'rxjs/operators';
+import {map, single} from 'rxjs/operators';
 
 @Component({
     selector: 'app-service-publish-final-step',
@@ -44,7 +44,9 @@ export class ServicePublishFinalStepComponent extends Reinitable {
                 ServicePublishSteps.Final, {master, masterLocation}
             );
         }
-        this.servicePublish.publish().subscribe((service) => this.router.navigate(['service', service.id ]));
+        this.servicePublish.publish()
+            .pipe(single())
+            .subscribe((service) => this.router.navigate(['service', service.id ]));
     }
 
     protected init(): void {

--- a/src/app/service/services/service-publish.service.ts
+++ b/src/app/service/services/service-publish.service.ts
@@ -107,45 +107,33 @@ export class ServicePublishService {
     }
 
     private createService(service: Service, master: Master): Observable<Service> {
-        service.professional = master.id;
-
-        return this.serviceApi.create(service);
+        return this.serviceApi.create({ ...service, professional: master.id });
     }
 
     private createPhotos(photos: ServicePhoto[], service: Service): Observable<ServicePhoto[]> {
+        // TODO: shouldn't mutate method's arguments
         photos.forEach(photo => photo.service = service.id);
 
         return this.servicePhotosApi.createList(photos);
     }
 
     private createSchedule(schedule: ServiceSchedule[], service: Service): Observable<ServiceSchedule[]> {
-        schedule?.forEach(v => v.service = service.id);
-
-        return this.serviceScheduleApi.createList(schedule);
+        return this.serviceScheduleApi.createList(schedule?.map(v => ({ ...v, service: service.id })));
     }
 
     private createMasterSchedule(schedule: MasterSchedule[], master: Master): Observable<MasterSchedule[]> {
-        schedule?.forEach(v => v.professional = master.id);
-
-        return this.masterScheduleApi.createList(schedule);
+        return this.masterScheduleApi.createList(schedule?.map(v => ({ ...v, professional: master.id })));
     }
 
     private createMasterLocation(location: MasterLocation, master: Master): Observable<MasterLocation> {
-        location.professional = master.id;
-
-        return this.masterLocationApi.create(location);
+        return this.masterLocationApi.create({ ...location, professional: master.id });
     }
 
     private createPrice(price: Price, service: Service): Observable<Price> {
-        price.service = service.id;
-
-        return this.servicePriceApi.create(price);
+        return this.servicePriceApi.create({ ...price, service: service.id });
     }
 
     private createServiceLocation(location: ServiceLocation, service: Service, masterLoc: MasterLocation): Observable<ServiceLocation> {
-        location.location = masterLoc.id;
-        location.service = service.id;
-
-        return this.serviceLocationApi.create(location);
+        return this.serviceLocationApi.create({ ...location, location: masterLoc.id, service: service.id });
     }
 }

--- a/src/app/shared/components/main-menu/main-menu.component.html
+++ b/src/app/shared/components/main-menu/main-menu.component.html
@@ -1,7 +1,7 @@
 <ion-header>
     <ion-toolbar>
         <ion-item lines="none">
-            <ion-label> {{ 'Навигация' | translate }}</ion-label>
+            <ion-label> {{ 'template.main-menu-title' | translate }}</ion-label>
         </ion-item>
     </ion-toolbar>
 </ion-header>

--- a/src/environments/environment.prod.ts.dist
+++ b/src/environments/environment.prod.ts.dist
@@ -56,7 +56,7 @@ export const environment = {
         messages_sent: '/en/api/communication/messages/sent/',
         fcm_devices: '/en/api/communication/devices/fcm/',
         master_photos: '/en/api/accounts/professional-photos/',
-        master_schedule: '/en/api/accounts/professional-schedule',
+        master_schedule: '/en/api/accounts/professional-schedule/',
         services_readonly: '/en/api/services/services/',
         service_tag_readonly: '/en/api/services/tags/',
         master_photos_readonly: '/en/api/professionals/professional-photos/',

--- a/src/environments/environment.ts.dist
+++ b/src/environments/environment.ts.dist
@@ -56,7 +56,7 @@ export const environment = {
         messages_sent: '/en/api/communication/messages/sent/',
         fcm_devices: '/en/api/communication/devices/fcm/',
         master_photos: '/en/api/accounts/professional-photos/',
-        master_schedule: '/en/api/accounts/professional-schedule',
+        master_schedule: '/en/api/accounts/professional-schedule/',
         services_readonly: '/en/api/services/services/',
         service_tag_readonly: '/en/api/services/tags/',
         master_photos_readonly: '/en/api/professionals/professional-photos/',


### PR DESCRIPTION
- Removed nested `.pipe()`s
- Removed "shared" static field. Used the standard `dismiss()`/`onDidDismiss()` way for passing the data.
- Removed excessive `then()`/`subscribe()` nesting
- Fixed `professional-schedule/` uri
- Fixed translation
- Now redirecting to the service page after creation